### PR TITLE
Added a box-sizing property

### DIFF
--- a/ungrid.css
+++ b/ungrid.css
@@ -1,4 +1,4 @@
 @media (min-width: 30em) {
     .row { width: 100%; display: table; table-layout: fixed; }
-    .col { display: table-cell; }
+    .col { display: table-cell; box-sizing: border-box; }
 }


### PR DESCRIPTION
When you add a fixed-width (for example, 80%) and then try to add a padding, the actual width changes. When setting the property `box-sizing: border-box;` the padding will not affect the total width of the element. So 80% is actually 80%. More information about this property in [CSS-Tricks Box Sizing](http://css-tricks.com/box-sizing/) and the extreme case in [Paul Irish's \* { Box-sizing: Border-box } FTW](http://www.paulirish.com/2012/box-sizing-border-box-ftw/)
