### PR TITLE
Flex flavor (w/ webkit prefixes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,15 @@ __ungrid__ is a tiny, responsive, table-based CSS grid system. The entire `ungri
 }
 ```
 
+The flex flavored version `ungrid-flex.css` is 71 bytes minified (137 bytes with prefixes, see [Can I Use Flex](http://caniuse.com/#search=flex)) :
+
+```css
+@media (min-width: 30em) {
+    .row { display: flex;flex-wrap: nowrap;  }
+    .col { flex: 1; }
+}
+```
+
 
 
 ## Get started
@@ -27,7 +36,7 @@ Install with [Bower](http://bower.io) `bower install ungrid` or just copy and pa
 
 ## How to use
 
-To use, simply put as many `.col`s as you wish in your `.row`s and the `.col`s will automatically be evenly spaced. This allows you to roll your own simple grids. [See it in action](http://codepen.io/chrisnager/pen/ypokv).
+To use, simply put as many `.col`s as you wish in your `.row`s and the `.col`s will automatically be evenly spaced. This allows you to roll your own simple grids. [See it in action](http://codepen.io/chrisnager/pen/ypokv) ([flex in action](http://codepen.io/sherbrow/pen/pJRBZx)).
 
 ```html
 <div class="row">

--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ __ungrid__ is a tiny, responsive, table-based CSS grid system. The entire `ungri
 }
 ```
 
-The flex flavored version `ungrid-flex.css` is 71 bytes minified (137 bytes with prefixes, see [Can I Use Flex](http://caniuse.com/#search=flex)) :
+The flex flavored version `ungrid-flex.css` is 76 bytes minified (142 bytes with prefixes, see [Can I Use Flex](http://caniuse.com/#search=flex)) :
 
 ```css
 @media (min-width: 30em) {
     .row { display: flex; flex-wrap: nowrap; }
-    .col { flex: 1; }
+    .col { flex-grow: 1; }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The flex flavored version `ungrid-flex.css` is 71 bytes minified (137 bytes with
 
 ```css
 @media (min-width: 30em) {
-    .row { display: flex;flex-wrap: nowrap;  }
+    .row { display: flex; flex-wrap: nowrap; }
     .col { flex: 1; }
 }
 ```

--- a/docs.css
+++ b/docs.css
@@ -1,106 +1,108 @@
-html {                                                                          
-    font: 24px/1.7 "Helvetica Neue", sans-serif;                                
-    text-align: center;                                                         
-    color: #222;                                                                
-}                                                                               
-                                                                                
-body {                                                                          
-    margin: 0;                                                                  
-}                                                                               
-                                                                                
-a {                                                                             
-    text-decoration: none;                                                      
-    color: teal;                                                                
-}                                                                               
-                                                                                
-h1 {                                                                            
-    letter-spacing: -0.05em;                                                    
-}                                                                               
-                                                                                
-h2 {                                                                            
-    font-size: 0.83333em;                                                       
-}                                                                               
-                                                                                
-p {                                                                             
-    font-size: 0.7em;                                                           
-}                                                                               
-                                                                                
-pre {                                                                           
-    border: 2px solid;                                                          
-    padding: 1em;                                                               
-    white-space: pre-wrap;                                                      
-    font-size: 0.54167em;                                                       
-    text-align: left;                                                           
-    background-color: #fff;                                                     
-}                                                                               
-                                                                                
-.info__inner > p > code {                                                       
-    padding: 0.25em;                                                            
-    border-radius: 4px;                                                         
-    border: 1px solid #bbb;                                                     
-}                                                                               
-                                                                                
-hr {                                                                            
-    max-width: 20em;                                                            
-    margin: 2em auto;                                                           
-    border: solid #ddd;                                                         
-    border-width: 1px 0 0;                                                      
-}                                                                               
-                                                                                
-.header {                                                                       
-    padding: 3em 1em;                                                           
-}                                                                               
-                                                                                
-.header > h1,                                                                   
-.header > p {                                                                   
-    margin-top: 0;                                                              
-    margin-bottom: 0;                                                           
-}                                                                               
-                                                                                
-.info {                                                                         
-    padding: 2em 1em;                                                           
-    overflow: hidden;                                                           
-    background-color: #f2f2f2;                                                  
-}                                                                               
-                                                                                
-.info__inner {                                                                  
-    max-width: 30em;                                                            
-    margin-right: auto;                                                         
-    margin-left: auto;                                                          
-}                                                                               
-                                                                                
-.row {                                                                          
-    margin-top: 1em;                                                            
-    margin-bottom: 1em;                                                         
-}                                                                               
-.row.col {                                                                      
-    margin-top: 0;                                                              
-    margin-bottom: 0;                                                           
-    padding: 0.5em;                                                             
-    box-sizing: border-box;                                                     
-}                                                                               
-                                                                                
-@media (max-width: 479px) {                                                     
-    .col {                                                                      
-        width: 100% !important;                                                 
-    }                                                                           
-}                                                                               
-                                                                                
-.col {                                                                          
-    height: 4em;                                                                
-    vertical-align: middle;                                                     
-    line-height: 4em;                                                           
-    background-color: teal;                                                     
-}                                                                               
-.row.col .col {                                                                 
-    height: 3em;                                                                
-    line-height: 3em;                                                           
-}                                                                               
-                                                                                
-.col:nth-of-type(2n) {                                                          
-    background-color: #95cbcb;                                                  
-}                                                                               
-                                                                                
-.footer {                                                                       
-    padding: 0.5rem 1rem 1.5em;                                                 
-}                                                                               
+html {
+    font: 24px/1.7 "Helvetica Neue", sans-serif;
+    text-align: center;
+    color: #222;
+}
+
+body {
+    margin: 0;
+}
+
+a {
+    text-decoration: none;
+    color: teal;
+}
+
+h1 {
+    letter-spacing: -0.05em;
+}
+
+h2 {
+    font-size: 0.83333em;
+}
+
+p {
+    font-size: 0.7em;
+}
+
+pre {
+    border: 2px solid;
+    padding: 1em;
+    white-space: pre-wrap;
+    font-size: 0.54167em;
+    text-align: left;
+    background-color: #fff;
+}
+
+.info__inner > p > code {
+    padding: 0.25em;
+    border-radius: 4px;
+    border: 1px solid #bbb;
+}
+
+hr {
+    max-width: 20em;
+    margin: 2em auto;
+    border: solid #ddd;
+    border-width: 1px 0 0;
+}
+
+.header {
+    padding: 3em 1em;
+}
+
+.header > h1,
+.header > p {
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.info {
+    padding: 2em 1em;
+    overflow: hidden;
+    background-color: #f2f2f2;
+}
+
+.info__inner {
+    max-width: 30em;
+    margin-right: auto;
+    margin-left: auto;
+}
+
+.row {
+    margin-top: 1em;
+    margin-bottom: 1em;
+}
+
+.row.col {
+    margin-top: 0;
+    margin-bottom: 0;
+    padding: 0.5em;
+    box-sizing: border-box;
+}
+
+@media (max-width: 479px) {
+    .col {
+        width: 100% !important;
+    }
+}
+
+.col {
+    height: 4em;
+    vertical-align: middle;
+    line-height: 4em;
+    background-color: teal;
+}
+
+.row.col .col {
+    height: 3em;
+    line-height: 3em;
+}
+
+.col:nth-of-type(2n) {
+    background-color: #95cbcb;
+}
+
+.footer {
+    padding: 0.5rem 1rem 1.5em;
+}

--- a/docs.css
+++ b/docs.css
@@ -73,6 +73,12 @@ hr {
     margin-top: 1em;
     margin-bottom: 1em;
 }
+.row.col {
+    margin-top: 0;
+    margin-bottom: 0;
+    padding: 0.5em;
+    box-sizing: border-box;
+}
 
 @media (max-width: 479px) {
     .col {
@@ -85,6 +91,10 @@ hr {
     vertical-align: middle;
     line-height: 4em;
     background-color: teal;
+}
+.row.col .col {
+    height: 3em;
+    line-height: 3em;
 }
 
 .col:nth-of-type(2n) {

--- a/flex.html
+++ b/flex.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=640">
         <title>ungrid - the simplest responsive css grid</title>
-        <link href="ungrid.min.css" rel="stylesheet">
+        <link href="ungrid-flex.min.css" rel="stylesheet">
         <link href="docs.css" rel="stylesheet">
     </head>
     <body>
@@ -13,7 +13,7 @@
             <h1><a href="//github.com/chrisnager/ungrid">ungrid</a></h1>
             <p>by <a href="//twitter.com/chrisnager">@chrisnager</a></p>
             <h2>the simplest responsive css grid</h2>
-            <p>Ready for the latest in CSS ? Check the <a href="flex.html">flex flavor</a> !</p>
+            <p>Not ready for the latest in CSS ? Check the <a href="./">table-based flavor</a>.</p>
         </div>
 
         <div class="info">
@@ -23,8 +23,8 @@
                 <hr>
                 <p>ungrid.css (97 bytes minified):</p>
                 <pre><code>@media (min-width: 30em) {
-    .row { width: 100%; display: table; table-layout: fixed; }
-    .col { display: table-cell; }
+    .row { display: flex;flex-wrap: nowrap;  }
+    .col { flex: 1; }
 }</code></pre>
             </div>
         </div>
@@ -129,35 +129,39 @@
          <div class="info">
             <div class="info__inner">
                 <h2>Need specific column widths?</h2>
-                <p>Go for it. Both fixed and percentage base widths work perfectly. You can even use them together. The remaining columns will take up the rest of the available space.</p>
+                <p>Flex is also ready for that, use flex-basis property with the shorthand :<br /><small>(flex-grow needs to be forced to 0)</small></p>
+                <pre><code>flex: 0 [WIDTH];
+flex: 0 15%;
+flex: 0 400px;</code></pre>
+                <p>Both fixed and percentage base widths work perfectly. You can even use them together. The remaining columns will take up the rest of the available space.</p>
             </div>
         </div>
 
        <div class="row">
-            <div class="col" style="width:80%">80%</div>
+            <div class="col" style="flex: 0 80%">80%</div>
             <div class="col">&#9884;</div>
         </div>
 
        <div class="row">
-            <div class="col" style="width:40%">40%</div>
-            <div class="col" style="width:20%">20%</div>
-            <div class="col" style="width:40%">40%</div>
+            <div class="col" style="flex: 0 40%">40%</div>
+            <div class="col" style="flex: 0 20%">20%</div>
+            <div class="col" style="flex: 0 40%">40%</div>
         </div>
 
         <div class="row">
             <div class="col">&#9884;</div>
-            <div class="col" style="width:425px">425px</div>
+            <div class="col" style="flex: 0 425px">425px</div>
         </div>
 
         <div class="row">
-            <div class="col" style="width:15%">15%</div>
-            <div class="col" style="width:200px">200px</div>
+            <div class="col" style="flex: 0 15%">15%</div>
+            <div class="col" style="flex: 0 200px">200px</div>
             <div class="col">&#9884;</div>
-            <div class="col" style="width:25%">25%</div>
+            <div class="col" style="flex: 0 25%">25%</div>
         </div>
 
         <div class="footer">
-            <p><b>ungrid</b> on <a href="//github.com/chrisnager/ungrid">github</a> &middot; crafted by <a href="//twitter.com/chrisnager">@chrisnager</a> &middot; try it out on <a href="//codepen.io/chrisnager/pen/ypokv">codepen</a></p>
+            <p><b>ungrid</b> on <a href="//github.com/chrisnager/ungrid">github</a> &middot; crafted by <a href="//twitter.com/chrisnager">@chrisnager</a> &middot; try it out on <a href="//codepen.io/sherbrow/pen/pJRBZx">codepen</a></p>
         </div>
 
         <script>

--- a/flex.html
+++ b/flex.html
@@ -128,8 +128,46 @@
 
          <div class="info">
             <div class="info__inner">
+                <h2>Nesting is super easy !</h2>
+                <p>A <code>.col</code> can be a <code>.row</code>, and that's all.</p>
+                <pre><code>&lt;div class="row"&gt;
+    &lt;div class="col"&gt;&lt;/div&gt;
+    &lt;div class="col row"&gt;
+        &lt;div class="col"&gt;&lt;/div&gt;
+        &lt;div class="col"&gt;&lt;/div&gt;
+    &lt;/div&gt;
+&lt;/div&gt;</code></pre>
+            </div>
+        </div>
+        
+        <div class="row">
+            <div class="col">&#9884;</div>
+            <div class="col row">
+                <div class="col">&#9884;</div>
+                <div class="col">&#9884;</div>
+                <div class="col">&#9884;</div>
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="col row">
+                <div class="col">&#9884;</div>
+                <div class="col">&#9884;</div>
+            </div>
+            <div class="col row">
+                <div class="col">&#9884;</div>
+                <div class="col">&#9884;</div>
+                <div class="col">&#9884;</div>
+                <div class="col">&#9884;</div>
+                <div class="col">&#9884;</div>
+            </div>
+            <div class="col">&#9884;</div>
+        </div>
+
+         <div class="info">
+            <div class="info__inner">
                 <h2>Need specific column widths?</h2>
-                <p>Flex is also ready for that, use flex-basis property with the shorthand :<br /><small>(flex-grow needs to be forced to 0)</small></p>
+                <p>Flex is also ready for that, use <code>flex-basis</code> property with the shorthand :<br /><small>(<code>flex-grow</code> needs to be forced to <code>0</code>)</small></p>
                 <pre><code>flex: 0 [WIDTH];
 flex: 0 15%;
 flex: 0 400px;</code></pre>

--- a/flex.html
+++ b/flex.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=640">
         <title>ungrid - the simplest responsive css grid</title>
-        <link href="ungrid-flex.min.css" rel="stylesheet">
+        <link href="ungrid-flex-prefix.min.css" rel="stylesheet">
         <link href="docs.css" rel="stylesheet">
     </head>
     <body>
@@ -21,9 +21,9 @@
                 <p><b>ungrid</b> is a responsive, table-based CSS grid system. To use, simply put as many <code>.col</code>s as you wish in your <code>.row</code>s and the <code>.col</code>s will automatically be evenly spaced. This allows you to roll your own simple grids.</p>
                 <p><iframe src="http://ghbtns.com/github-btn.html?user=chrisnager&amp;repo=ungrid&amp;type=watch&amp;size=large" allowtransparency="true" frameborder="0" scrolling="0" width="77px" height="30px"></iframe></p>
                 <hr>
-                <p>ungrid.css (97 bytes minified):</p>
+                <p>ungrid-flex.css (71 bytes minified):</p>
                 <pre><code>@media (min-width: 30em) {
-    .row { display: flex;flex-wrap: nowrap;  }
+    .row { display: flex; flex-wrap: nowrap; }
     .col { flex: 1; }
 }</code></pre>
             </div>

--- a/flex.html
+++ b/flex.html
@@ -21,10 +21,10 @@
                 <p><b>ungrid</b> is a responsive, table-based CSS grid system. To use, simply put as many <code>.col</code>s as you wish in your <code>.row</code>s and the <code>.col</code>s will automatically be evenly spaced. This allows you to roll your own simple grids.</p>
                 <p><iframe src="http://ghbtns.com/github-btn.html?user=chrisnager&amp;repo=ungrid&amp;type=watch&amp;size=large" allowtransparency="true" frameborder="0" scrolling="0" width="77px" height="30px"></iframe></p>
                 <hr>
-                <p>ungrid-flex.css (71 bytes minified):</p>
+                <p>ungrid-flex.css (76 bytes minified):</p>
                 <pre><code>@media (min-width: 30em) {
     .row { display: flex; flex-wrap: nowrap; }
-    .col { flex: 1; }
+    .col { flex-grow: 1; }
 }</code></pre>
             </div>
         </div>

--- a/ungrid-flex-prefix.css
+++ b/ungrid-flex-prefix.css
@@ -1,0 +1,7 @@
+@media (min-width: 30em) {
+    .row {
+        display: -webkit-flex;-webkit-flex-wrap: nowrap;
+        display: flex;flex-wrap: nowrap;
+    }
+    .col { -webkit-flex-grow: 1;flex: 1; }
+}

--- a/ungrid-flex-prefix.css
+++ b/ungrid-flex-prefix.css
@@ -1,7 +1,7 @@
 @media (min-width: 30em) {
     .row {
-        display: -webkit-flex;-webkit-flex-wrap: nowrap;
-        display: flex;flex-wrap: nowrap;
+        display: -webkit-flex; -webkit-flex-wrap: nowrap;
+        display: flex; flex-wrap: nowrap;
     }
-    .col { -webkit-flex-grow: 1;flex: 1; }
+    .col { -webkit-flex-grow: 1; flex: 1; }
 }

--- a/ungrid-flex-prefix.css
+++ b/ungrid-flex-prefix.css
@@ -3,5 +3,5 @@
         display: -webkit-flex; -webkit-flex-wrap: nowrap;
         display: flex; flex-wrap: nowrap;
     }
-    .col { -webkit-flex-grow: 1; flex: 1; }
+    .col { -webkit-flex-grow: 1; flex-grow: 1; }
 }

--- a/ungrid-flex-prefix.min.css
+++ b/ungrid-flex-prefix.min.css
@@ -1,0 +1,1 @@
+@media(min-width:30em){.row{display:-webkit-flex;-webkit-flex-wrap:nowrap;display:flex;flex-wrap:nowrap}.col{-webkit-flex-grow:1;flex:1}}

--- a/ungrid-flex-prefix.min.css
+++ b/ungrid-flex-prefix.min.css
@@ -1,1 +1,1 @@
-@media(min-width:30em){.row{display:-webkit-flex;-webkit-flex-wrap:nowrap;display:flex;flex-wrap:nowrap}.col{-webkit-flex-grow:1;flex:1}}
+@media(min-width:30em){.row{display:-webkit-flex;-webkit-flex-wrap:nowrap;display:flex;flex-wrap:nowrap}.col{-webkit-flex-grow:1;flex-grow:1}}

--- a/ungrid-flex.css
+++ b/ungrid-flex.css
@@ -1,4 +1,4 @@
 @media (min-width: 30em) {
-    .row { display: flex;flex-wrap: nowrap;  }
+    .row { display: flex; flex-wrap: nowrap; }
     .col { flex: 1; }
 }

--- a/ungrid-flex.css
+++ b/ungrid-flex.css
@@ -1,4 +1,4 @@
 @media (min-width: 30em) {
     .row { display: flex; flex-wrap: nowrap; }
-    .col { flex: 1; }
+    .col { flex-grow: 1; }
 }

--- a/ungrid-flex.css
+++ b/ungrid-flex.css
@@ -1,0 +1,4 @@
+@media (min-width: 30em) {
+    .row { display: flex;flex-wrap: nowrap;  }
+    .col { flex: 1; }
+}

--- a/ungrid-flex.min.css
+++ b/ungrid-flex.min.css
@@ -1,1 +1,1 @@
-@media(min-width:30em){.row{display:flex;flex-wrap:nowrap}.col{flex:1}}
+@media(min-width:30em){.row{display:flex;flex-wrap:nowrap}.col{flex-grow:1}}

--- a/ungrid-flex.min.css
+++ b/ungrid-flex.min.css
@@ -1,0 +1,1 @@
+@media(min-width:30em){.row{display:flex;flex-wrap:nowrap}.col{flex:1}}


### PR DESCRIPTION
The flex flavored version as I think it would allow a lot more than _mere_ tables.

Safari is till using prefixes but that's not too problematic I guess : [Can I Use Flex](http://caniuse.com/#search=flex)

Added a doc page too (a copy of the index.html) and it would be even better if it explained the flex version and a few of the very useful flex properties (maybe even a .css with classes to apply those properties to the rows and cols).

http://sherbrow.github.io/ungrid/flex.html
