### PR TITLE
Update ungrid.css

### DIFF
--- a/ungrid.css
+++ b/ungrid.css
@@ -1,4 +1,4 @@
 @media (min-width: 30em) {
     .row { width: 100%; display: table; table-layout: fixed; }
-    .col { display: table-cell; }
+    .col { display: table-cell; vertical-align: top; }
 }


### PR DESCRIPTION
In use case where a container with class .col contains only an image, text in an adjacent .col in same .row will be forced to the bottom of its container. vertical-align: top; on .col resets this.

Demo of issue here: http://codepen.io/jonhickman/pen/VmeBwM